### PR TITLE
Fix progress tracking duplication

### DIFF
--- a/find_bad_images.py
+++ b/find_bad_images.py
@@ -828,13 +828,19 @@ def process_images(directory, formats, dry_run=True, repair=False,
             # Save progress periodically
             current_time = time.time()
             if save_progress_interval > 0 and current_time - last_progress_save >= save_progress_interval * 60:
-                # Get processed files up to the current position
-                newly_processed = image_files[:self.n]
-                processed_files.extend(newly_processed)
-                
-                # Save the progress
-                save_progress(session_id, directory, formats, recursive, 
-                             processed_files, bad_files, repaired_files, progress_dir)
+                # Save the progress using the list of files that have actually
+                # completed processing. ``processed_files`` is updated as each
+                # future finishes so we can safely persist it as-is.
+                save_progress(
+                    session_id,
+                    directory,
+                    formats,
+                    recursive,
+                    processed_files,
+                    bad_files,
+                    repaired_files,
+                    progress_dir,
+                )
                 
                 last_progress_save = current_time
                 logging.debug(f"Progress saved at {self.n} / {len(image_files)} files")


### PR DESCRIPTION
## Summary
- correct progress saving logic so processed files are not repeatedly added

## Testing
- `python3 -m py_compile find_bad_images.py`
