### PR TITLE
Improve RAT Finder with EOF data detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,7 +693,7 @@ The 2PAC toolkit now includes a powerful steganography detection tool called **R
 <table>
 <tr>
 <td width="80" align="center">🔍</td>
-<td><b>Multiple Detection Methods</b><br>Combines six different analysis techniques to detect various steganography approaches, including LSB, DCT manipulation, and metadata hiding</td>
+<td><b>Multiple Detection Methods</b><br>Combines seven different analysis techniques to detect various steganography approaches, including LSB, DCT manipulation, metadata hiding, and trailing data after EOF</td>
 </tr>
 <tr>
 <td align="center">🔄</td>

--- a/docs/rat_finder.md
+++ b/docs/rat_finder.md
@@ -18,7 +18,7 @@ RAT Finder is a powerful steganography detection tool designed to identify hidde
 
 ## 🚀 Features
 
-- **Multi-technique Detection:** Employs five different analysis methods to catch varied steganographic techniques
+- **Multi-technique Detection:** Employs seven different analysis methods to catch varied steganographic techniques
 - **Confidence-based Reporting:** Assigns confidence scores to help prioritize suspicious files
 - **Visual Analysis Reports:** Generates detailed visual reports for suspicious images
 - **Adjustable Sensitivity:** Customize detection thresholds to balance false positives and negatives
@@ -236,6 +236,33 @@ levels across channels.
 </tr>
 </table>
 
+### 7. EOF/Trailing Data Analysis
+
+<table>
+<tr>
+<td width="60%" valign="top">
+
+**What it detects:**
+- Bytes appended after the official end-of-file marker
+- Hidden payloads stored after JPEG or PNG images
+
+**Implementation details:**
+- Locates the final EOF marker (`FFD9` for JPEG, `IEND` for PNG)
+- Counts any bytes that follow the marker
+- Confidence increases with the size of trailing data
+
+</td>
+<td width="40%">
+
+```
+JPEG ... FFD9 <extra bytes>
+PNG  ... IEND\xAE\x42\x60\x82 <extra bytes>
+```
+
+</td>
+</tr>
+</table>
+
 ## 📊 Confidence Scoring
 
 RAT Finder uses a weighted confidence scoring system:
@@ -246,7 +273,8 @@ RAT Finder uses a weighted confidence scoring system:
 | Error Level Analysis (ELA) | 20% | Effective for JPEG manipulations |
 | Histogram Analysis | 20% | Effective for DCT and statistical anomalies |
 | Visual Noise Analysis | 15% | Good for detecting spread spectrum methods |
-| File Size Analysis | 10% | Identifies appended data and size anomalies |
+| File Size Analysis | 10% | Identifies disproportionate file sizes |
+| Trailing Data Analysis | 10% | Detects bytes after end-of-file markers |
 | Metadata Analysis | 10% | Finds hidden content in file metadata |
 
 The overall confidence score is calculated as a weighted sum of individual detection methods. Images with scores above the threshold (dependent on sensitivity setting) are flagged as suspicious.
@@ -334,7 +362,7 @@ The following table shows RAT Finder's effectiveness against various steganograp
 | **JPEG Manipulation** | ★★★★☆ (High) | Error Level Analysis, Visual Noise Analysis |
 | **Palette-Based** | ★★★☆☆ (Moderate) | Histogram Analysis, File Size Analysis |
 | **Metadata/Header** | ★★★★★ (Very High) | Metadata Analysis |
-| **Appended Data** | ★★★★★ (Very High) | File Size Analysis |
+| **Appended Data** | ★★★★★ (Very High) | Trailing Data Analysis |
 | **Spread Spectrum** | ★★☆☆☆ (Low) | Visual Noise Analysis |
 | **Error-Correcting Code** | ★★☆☆☆ (Low) | LSB Analysis, Histogram Analysis |
 

--- a/rat_finder.py
+++ b/rat_finder.py
@@ -517,6 +517,41 @@ def check_metadata_anomalies(image_path):
         logging.debug(f"Error analyzing metadata in {image_path}: {str(e)}")
         return False, 0, {"error": str(e)}
 
+def check_trailing_data(image_path):
+    """Detect suspicious data appended after the official end markers."""
+    try:
+        with open(image_path, 'rb') as f:
+            data = f.read()
+
+        appended_bytes = 0
+        lower = image_path.lower()
+
+        if lower.endswith(('.jpg', '.jpeg', '.jfif')):
+            marker = data.rfind(b'\xFF\xD9')
+            if marker != -1 and marker < len(data) - 2:
+                appended_bytes = len(data) - marker - 2
+        elif lower.endswith('.png'):
+            marker = data.rfind(b'\x00\x00\x00\x00IEND\xAEB\x60\x82')
+            if marker != -1 and marker < len(data) - 12:
+                appended_bytes = len(data) - marker - 12
+        else:
+            return False, 0, {"error": "unsupported format"}
+
+        is_suspicious = appended_bytes > 0
+        confidence = 0
+        if is_suspicious:
+            ratio = appended_bytes / len(data)
+            confidence = min(95, 50 + int(ratio * 500))
+
+        details = {
+            "appended_bytes": appended_bytes
+        }
+
+        return is_suspicious, confidence, details
+    except Exception as e:
+        logging.debug(f"Error analyzing trailing data in {image_path}: {str(e)}")
+        return False, 0, {"error": str(e)}
+
 def check_visual_noise_anomalies(image_path):
     """
     Analyze visual noise patterns to detect potential steganography.
@@ -624,7 +659,14 @@ def analyze_image(image_path, sensitivity='medium'):
             'confidence': metadata_result[1],
             'details': metadata_result[2]
         }
-        
+
+        trailing_result = check_trailing_data(image_path)
+        results['trailing_data_analysis'] = {
+            'suspicious': trailing_result[0],
+            'confidence': trailing_result[1],
+            'details': trailing_result[2]
+        }
+
         noise_result = check_visual_noise_anomalies(image_path)
         results['visual_noise_analysis'] = {
             'suspicious': noise_result[0],
@@ -656,6 +698,7 @@ def analyze_image(image_path, sensitivity='medium'):
             'histogram_analysis': 0.20,      # Histogram patterns are strong indicators
             'file_size_analysis': 0.10,      # Size can be indicative
             'metadata_analysis': 0.10,       # Metadata less common but useful indicator
+            'trailing_data_analysis': 0.10,  # Detects data after EOF markers
             'visual_noise_analysis': 0.15,   # Visual noise can be a good indicator
             'ela_analysis': 0.20            # Error Level Analysis is effective for JPEG manipulation
         }
@@ -873,10 +916,20 @@ def create_visual_report(image_path, confidence, details, output_dir):
                     else:
                         assessment = "NORMAL: Size within expected range"
                     
-                    axs[2, 0].annotate(assessment, xy=(0.05, 0.05), xycoords='axes fraction', 
+                    axs[2, 0].annotate(assessment, xy=(0.05, 0.05), xycoords='axes fraction',
                                      fontsize=9, verticalalignment='bottom')
+
+                    if 'trailing_data_analysis' in details:
+                        tdata = details['trailing_data_analysis']['details']
+                        if tdata.get('appended_bytes', 0) > 0:
+                            axs[2, 0].annotate(
+                                f"Appended data: {tdata['appended_bytes']} bytes",
+                                xy=(0.05, 0.85), xycoords='axes fraction',
+                                fontsize=9, verticalalignment='bottom',
+                                color='red'
+                            )
                 else:
-                    axs[2, 0].text(0.5, 0.5, "Size analysis data not available", 
+                    axs[2, 0].text(0.5, 0.5, "Size analysis data not available",
                                  horizontalalignment='center', verticalalignment='center')
                     axs[2, 0].axis('off')
             else:


### PR DESCRIPTION
## Summary
- add trailing data detection in rat_finder
- visualize appended bytes in analysis reports
- update weights and docs for new detection method
- document seventh detection method in README and docs

## Testing
- `python -m py_compile rat_finder.py`

------
https://chatgpt.com/codex/tasks/task_e_6875e11110948321ac78a2049b0cb01f